### PR TITLE
Add TrafficManagementService for V2X traffic management

### DIFF
--- a/scenarios/artery/services.xml
+++ b/scenarios/artery/services.xml
@@ -13,4 +13,10 @@
 			<penetration rate="0.1" />
 		</filters>
 	</service>
+	<service type="artery.application.TrafficManagementService">
+		<listener port="4712" />
+		<filters>
+			<penetration rate="0.3" />
+		</filters>
+	</service>
 </services>

--- a/src/artery/application/TrafficManagementService.cc
+++ b/src/artery/application/TrafficManagementService.cc
@@ -1,0 +1,305 @@
+/*
+ * Artery V2X Simulation Framework
+ * Copyright 2025 Devin AI
+ * Licensed under GPLv2, see COPYING file for detailed license and warranty terms.
+ */
+
+#include "TrafficManagementService.h"
+#include "artery/application/LocalDynamicMap.h"
+#include "artery/application/Timer.h"
+#include "artery/application/VehicleDataProvider.h"
+#include "artery/application/SampleBufferAlgorithm.h"
+#include "artery/application/Asn1PacketVisitor.h"
+#include <vanetza/btp/data_request.hpp>
+#include <vanetza/btp/ports.hpp>
+#include <vanetza/dcc/profile.hpp>
+#include <vanetza/geonet/interface.hpp>
+#include <vanetza/facilities/cam_functions.hpp>
+#include <vanetza/units/acceleration.hpp>
+#include <vanetza/units/time.hpp>
+#include <boost/units/base_units/metric/hour.hpp>
+#include <boost/units/systems/si/length.hpp>
+#include <boost/units/systems/si/time.hpp>
+#include <boost/units/systems/si/prefixes.hpp>
+
+static const auto hour = 3600.0 * boost::units::si::seconds;
+static const auto km_per_hour = boost::units::si::kilo * boost::units::si::meter / hour;
+
+using namespace omnetpp;
+using namespace vanetza;
+
+namespace artery
+{
+
+static const simsignal_t scSignalTrafficManagement = cComponent::registerSignal("TrafficManagement");
+
+Define_Module(TrafficManagementService)
+
+TrafficManagementService::TrafficManagementService() :
+    mCongestionSpeedThreshold(30.0),
+    mHighDensityThreshold(10.0),
+    mRecommendedSpeed(50.0),
+    mAnalysisInterval(5.0),
+    mMessageValidityDuration(60.0),
+    mLocalDynamicMap(nullptr),
+    mVehicleDataProvider(nullptr),
+    mTimer(nullptr),
+    mAnalysisTimer(nullptr),
+    mCongestionDetected(false),
+    mSequenceNumber(0)
+{
+}
+
+TrafficManagementService::~TrafficManagementService()
+{
+    cancelAndDelete(mAnalysisTimer);
+}
+
+void TrafficManagementService::initialize()
+{
+    ItsG5BaseService::initialize();
+    
+    mCongestionSpeedThreshold = par("congestionSpeedThreshold").doubleValue();
+    mHighDensityThreshold = par("highDensityThreshold").doubleValue();
+    mRecommendedSpeed = par("recommendedSpeed").doubleValue();
+    mAnalysisInterval = par("analysisInterval").doubleValue();
+    mMessageValidityDuration = par("messageValidityDuration").doubleValue();
+    
+    mLocalDynamicMap = &getFacilities().get_const<LocalDynamicMap>();
+    mVehicleDataProvider = &getFacilities().get_const<VehicleDataProvider>();
+    mTimer = &getFacilities().get_const<Timer>();
+    
+    mSpeedSampler.setDuration(SimTime(30.0));
+    mSpeedSampler.setInterval(SimTime(1.0));
+    
+    mAnalysisTimer = new cMessage("Traffic Analysis");
+    scheduleAt(simTime() + mAnalysisInterval, mAnalysisTimer);
+    
+    subscribe(scSignalTrafficManagement);
+}
+
+void TrafficManagementService::finish()
+{
+    ItsG5BaseService::finish();
+}
+
+void TrafficManagementService::handleMessage(cMessage* msg)
+{
+    Enter_Method("handleMessage");
+    
+    if (msg == mAnalysisTimer) {
+        trigger();
+        scheduleAt(simTime() + mAnalysisInterval, mAnalysisTimer);
+    }
+}
+
+void TrafficManagementService::indicate(const btp::DataIndication& indication, std::unique_ptr<vanetza::UpPacket> packet)
+{
+    Enter_Method("indicate");
+    
+    Asn1PacketVisitor<vanetza::asn1::Denm> visitor;
+    const vanetza::asn1::Denm* denm = boost::apply_visitor(visitor, *packet);
+    
+    if (denm) {
+        EV_INFO << "Received traffic management DENM message\n";
+    }
+}
+
+void TrafficManagementService::trigger()
+{
+    Enter_Method("trigger");
+    
+    mSpeedSampler.feed(mVehicleDataProvider->speed(), mVehicleDataProvider->updated());
+    
+    bool congestionNow = detectCongestion();
+    bool slowTraffic = detectSlowTraffic();
+    
+    if (congestionNow && !mCongestionDetected) {
+        mCongestionDetected = true;
+        mLastCongestionMessage = simTime();
+        
+        auto message = createCongestionMessage();
+        auto request = createTrafficRequest();
+        
+        sendDenm(std::move(message), request);
+        
+        EV_INFO << "Traffic congestion detected - broadcasting DENM\n";
+    }
+    
+    if (shouldRecommendSpeedChange()) {
+        mLastSpeedRecommendation = simTime();
+        
+        auto message = createSpeedRecommendationMessage();
+        auto request = createTrafficRequest();
+        
+        sendDenm(std::move(message), request);
+        
+        EV_INFO << "Broadcasting speed recommendation\n";
+    }
+    
+    if (!congestionNow && mCongestionDetected) {
+        mCongestionDetected = false;
+        EV_INFO << "Traffic congestion cleared\n";
+    }
+}
+
+bool TrafficManagementService::detectCongestion()
+{
+    return checkVehicleDensity() && checkAverageSpeed();
+}
+
+bool TrafficManagementService::detectSlowTraffic()
+{
+    using vanetza::units::Velocity;
+    
+    const auto& speedSamples = mSpeedSampler.buffer();
+    if (speedSamples.empty()) return false;
+    
+    static const Velocity slowThreshold { mCongestionSpeedThreshold * km_per_hour };
+    
+    return speedSamples.latest().value < slowThreshold;
+}
+
+bool TrafficManagementService::checkVehicleDensity()
+{
+    using vanetza::facilities::distance;
+    using vanetza::units::Length;
+    using vanetza::units::si::meter;
+    
+    const Length analysisRadius { 100.0 * meter };
+    
+    LocalDynamicMap::CamPredicate nearbyVehicles = [&](const LocalDynamicMap::Cam& msg) {
+        const auto& bc = msg->cam.camParameters.basicContainer;
+        return distance(bc.referencePosition, 
+                       mVehicleDataProvider->latitude(), 
+                       mVehicleDataProvider->longitude()) <= analysisRadius;
+    };
+    
+    unsigned vehicleCount = mLocalDynamicMap->count(nearbyVehicles);
+    double density = vehicleCount / 1.0;
+    
+    return density >= mHighDensityThreshold;
+}
+
+bool TrafficManagementService::checkAverageSpeed()
+{
+    using vanetza::units::Velocity;
+    
+    const auto& speedSamples = mSpeedSampler.buffer();
+    if (speedSamples.duration() < SimTime(10.0)) return false;
+    
+    static const Velocity congestionThreshold { mCongestionSpeedThreshold * km_per_hour };
+    const Velocity avgSpeed = average(speedSamples);
+    
+    return avgSpeed <= congestionThreshold;
+}
+
+bool TrafficManagementService::shouldRecommendSpeedChange()
+{
+    if (simTime() - mLastSpeedRecommendation < SimTime(30.0)) return false;
+    
+    return detectSlowTraffic() || mCongestionDetected;
+}
+
+vanetza::asn1::Denm TrafficManagementService::createCongestionMessage()
+{
+    vanetza::asn1::Denm message;
+    
+    message->header.protocolVersion = 2;
+    message->header.messageID = ItsPduHeader__messageID_denm;
+    message->header.stationID = mVehicleDataProvider->station_id();
+    
+    message->denm.management.actionID.originatingStationID = mVehicleDataProvider->station_id();
+    message->denm.management.actionID.sequenceNumber = ++mSequenceNumber;
+    message->denm.management.detectionTime = mTimer->getCurrentTime();
+    message->denm.management.referenceTime = mTimer->getCurrentTime();
+    
+    message->denm.management.relevanceDistance = vanetza::asn1::allocate<RelevanceDistance_t>();
+    *message->denm.management.relevanceDistance = RelevanceDistance_lessThan1000m;
+    message->denm.management.relevanceTrafficDirection = vanetza::asn1::allocate<RelevanceTrafficDirection_t>();
+    *message->denm.management.relevanceTrafficDirection = RelevanceTrafficDirection_allTrafficDirections;
+    message->denm.management.validityDuration = vanetza::asn1::allocate<ValidityDuration_t>();
+    *message->denm.management.validityDuration = static_cast<ValidityDuration_t>(mMessageValidityDuration.dbl());
+    message->denm.management.stationType = StationType_unknown;
+    
+    message->denm.situation = vanetza::asn1::allocate<SituationContainer_t>();
+    message->denm.situation->informationQuality = 7;
+    message->denm.situation->eventType.causeCode = CauseCodeType_trafficCondition;
+    message->denm.situation->eventType.subCauseCode = 1;
+    
+    return message;
+}
+
+vanetza::asn1::Denm TrafficManagementService::createSpeedRecommendationMessage()
+{
+    vanetza::asn1::Denm message;
+    
+    message->header.protocolVersion = 2;
+    message->header.messageID = ItsPduHeader__messageID_denm;
+    message->header.stationID = mVehicleDataProvider->station_id();
+    
+    message->denm.management.actionID.originatingStationID = mVehicleDataProvider->station_id();
+    message->denm.management.actionID.sequenceNumber = ++mSequenceNumber;
+    message->denm.management.detectionTime = mTimer->getCurrentTime();
+    message->denm.management.referenceTime = mTimer->getCurrentTime();
+    
+    message->denm.management.relevanceDistance = vanetza::asn1::allocate<RelevanceDistance_t>();
+    *message->denm.management.relevanceDistance = RelevanceDistance_lessThan500m;
+    message->denm.management.relevanceTrafficDirection = vanetza::asn1::allocate<RelevanceTrafficDirection_t>();
+    *message->denm.management.relevanceTrafficDirection = RelevanceTrafficDirection_allTrafficDirections;
+    message->denm.management.validityDuration = vanetza::asn1::allocate<ValidityDuration_t>();
+    *message->denm.management.validityDuration = 30;
+    message->denm.management.stationType = StationType_unknown;
+    
+    message->denm.situation = vanetza::asn1::allocate<SituationContainer_t>();
+    message->denm.situation->informationQuality = 5;
+    message->denm.situation->eventType.causeCode = CauseCodeType_trafficCondition;
+    message->denm.situation->eventType.subCauseCode = 2;
+    
+    return message;
+}
+
+vanetza::btp::DataRequestB TrafficManagementService::createTrafficRequest()
+{
+    namespace geonet = vanetza::geonet;
+    using vanetza::units::si::seconds;
+    using vanetza::units::si::meter;
+
+    vanetza::btp::DataRequestB request;
+    request.destination_port = btp::ports::DENM;
+    request.gn.traffic_class.tc_id(static_cast<unsigned>(dcc::Profile::DP2));
+    request.gn.transport_type = geonet::TransportType::GBC;
+    request.gn.communication_profile = geonet::CommunicationProfile::ITS_G5;
+    request.gn.its_aid = aid::DEN;
+
+    geonet::Area destination;
+    geonet::Circle destination_shape;
+    destination_shape.r = 500.0 * meter;
+    destination.shape = destination_shape;
+    destination.position.latitude = mVehicleDataProvider->latitude();
+    destination.position.longitude = mVehicleDataProvider->longitude();
+    request.gn.destination = destination;
+
+    return request;
+}
+
+void TrafficManagementService::sendDenm(vanetza::asn1::Denm&& message, vanetza::btp::DataRequestB& request)
+{
+    using namespace vanetza;
+    using DenmConvertible = vanetza::convertible::byte_buffer_impl<vanetza::asn1::Denm>;
+    std::unique_ptr<geonet::DownPacket> payload { new geonet::DownPacket };
+    std::unique_ptr<vanetza::convertible::byte_buffer> denm { new DenmConvertible { std::make_shared<vanetza::asn1::Denm>(std::move(message)) } };
+    payload->layer(OsiLayer::Application) = vanetza::ByteBufferConvertible { std::move(denm) };
+    this->request(request, std::move(payload));
+}
+
+void TrafficManagementService::receiveSignal(cComponent* source, simsignal_t signal, cObject*, cObject*)
+{
+    Enter_Method("receiveSignal");
+    
+    if (signal == scSignalTrafficManagement) {
+        EV_INFO << "Received traffic management signal\n";
+    }
+}
+
+} // namespace artery

--- a/src/artery/application/TrafficManagementService.cc
+++ b/src/artery/application/TrafficManagementService.cc
@@ -203,7 +203,7 @@ bool TrafficManagementService::shouldRecommendSpeedChange()
 
 vanetza::asn1::Denm TrafficManagementService::createCongestionMessage()
 {
-    vanetza::asn1::Denm message;
+    auto message = vanetza::asn1::allocate<vanetza::asn1::Denm>();
     
     message->header.protocolVersion = 2;
     message->header.messageID = ItsPduHeader__messageID_denm;
@@ -232,7 +232,7 @@ vanetza::asn1::Denm TrafficManagementService::createCongestionMessage()
 
 vanetza::asn1::Denm TrafficManagementService::createSpeedRecommendationMessage()
 {
-    vanetza::asn1::Denm message;
+    auto message = vanetza::asn1::allocate<vanetza::asn1::Denm>();
     
     message->header.protocolVersion = 2;
     message->header.messageID = ItsPduHeader__messageID_denm;

--- a/src/artery/application/TrafficManagementService.h
+++ b/src/artery/application/TrafficManagementService.h
@@ -1,0 +1,73 @@
+/*
+ * Artery V2X Simulation Framework
+ * Copyright 2025 Devin AI
+ * Licensed under GPLv2, see COPYING file for detailed license and warranty terms.
+ */
+
+#ifndef ARTERY_TRAFFICMANAGEMENTSERVICE_H_
+#define ARTERY_TRAFFICMANAGEMENTSERVICE_H_
+
+#include "artery/application/ItsG5BaseService.h"
+#include "artery/application/Sampling.h"
+#include <vanetza/units/velocity.hpp>
+#include <vanetza/asn1/denm.hpp>
+#include <vanetza/btp/data_request.hpp>
+#include <omnetpp/simtime.h>
+#include <memory>
+
+namespace artery
+{
+
+class LocalDynamicMap;
+class Timer;
+class VehicleDataProvider;
+
+class TrafficManagementService : public ItsG5BaseService
+{
+public:
+    TrafficManagementService();
+    ~TrafficManagementService();
+
+    void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<vanetza::UpPacket>) override;
+    void trigger() override;
+    void receiveSignal(omnetpp::cComponent*, omnetpp::simsignal_t, omnetpp::cObject*, omnetpp::cObject*) override;
+
+protected:
+    void initialize() override;
+    void finish() override;
+    void handleMessage(omnetpp::cMessage*) override;
+
+private:
+private:
+    bool detectCongestion();
+    bool detectSlowTraffic();
+    bool shouldRecommendSpeedChange();
+    
+    vanetza::asn1::Denm createCongestionMessage();
+    vanetza::asn1::Denm createSpeedRecommendationMessage();
+    vanetza::btp::DataRequestB createTrafficRequest();
+    void sendDenm(vanetza::asn1::Denm&& message, vanetza::btp::DataRequestB& request);
+    
+    bool checkVehicleDensity();
+    bool checkAverageSpeed();
+    double mCongestionSpeedThreshold;
+    double mHighDensityThreshold;
+    double mRecommendedSpeed;
+    omnetpp::SimTime mAnalysisInterval;
+    omnetpp::SimTime mMessageValidityDuration;
+    
+    const LocalDynamicMap* mLocalDynamicMap;
+    const VehicleDataProvider* mVehicleDataProvider;
+    const Timer* mTimer;
+    SkipEarlySampler<vanetza::units::Velocity> mSpeedSampler;
+    
+    omnetpp::cMessage* mAnalysisTimer;
+    bool mCongestionDetected;
+    omnetpp::SimTime mLastCongestionMessage;
+    omnetpp::SimTime mLastSpeedRecommendation;
+    unsigned mSequenceNumber;
+};
+
+} // namespace artery
+
+#endif /* ARTERY_TRAFFICMANAGEMENTSERVICE_H_ */

--- a/src/artery/application/TrafficManagementService.h
+++ b/src/artery/application/TrafficManagementService.h
@@ -38,7 +38,6 @@ protected:
     void handleMessage(omnetpp::cMessage*) override;
 
 private:
-private:
     bool detectCongestion();
     bool detectSlowTraffic();
     bool shouldRecommendSpeedChange();
@@ -50,6 +49,7 @@ private:
     
     bool checkVehicleDensity();
     bool checkAverageSpeed();
+    
     double mCongestionSpeedThreshold;
     double mHighDensityThreshold;
     double mRecommendedSpeed;

--- a/src/artery/application/TrafficManagementService.ned
+++ b/src/artery/application/TrafficManagementService.ned
@@ -1,0 +1,20 @@
+/*
+ * Artery V2X Simulation Framework
+ * Copyright 2025 Devin AI
+ * Licensed under GPLv2, see COPYING file for detailed license and warranty terms.
+ */
+
+package artery.application;
+
+simple TrafficManagementService like ItsG5BaseService
+{
+    parameters:
+        double congestionSpeedThreshold @unit(kmph) = default(30kmph);
+        double highDensityThreshold = default(10.0);
+        double recommendedSpeed @unit(kmph) = default(50kmph);
+        double analysisInterval @unit(s) = default(5s);
+        double messageValidityDuration @unit(s) = default(60s);
+        
+        @class(TrafficManagementService);
+        @display("i=block/network2");
+}


### PR DESCRIPTION

# Add TrafficManagementService for V2X traffic management

## Summary

This PR introduces a new `TrafficManagementService` that implements intelligent traffic management capabilities for the Artery V2X simulation framework. The service detects traffic congestion conditions and broadcasts DENM (Decentralized Environmental Notification Message) alerts to optimize traffic flow.

**Key features:**
- **Congestion detection**: Combines vehicle density analysis (vehicles per 100m radius) and average speed monitoring
- **DENM broadcasting**: Sends standardized traffic condition messages and speed recommendations
- **Configurable parameters**: Thresholds for congestion detection, analysis intervals, and message validity periods
- **Integration**: Uses existing Artery facilities (LocalDynamicMap, VehicleDataProvider, Timer)

**Files changed:**
- `src/artery/application/TrafficManagementService.{h,cc}` - Core service implementation
- `src/artery/application/TrafficManagementService.ned` - OMNeT++ network description
- `scenarios/artery/services.xml` - Service configuration (30% penetration rate)

## Review & Testing Checklist for Human

⚠️ **Critical items to verify (architecture may need adjustment):**

- [ ] **Compilation check**: Verify the service compiles without errors - may need missing ASN.1 includes
- [ ] **Architecture validation**: Confirm extending `ItsG5BaseService` directly is correct vs. using `UseCase` pattern like `TrafficJamUseCase`
- [ ] **Simulation testing**: Run actual traffic scenarios to validate congestion detection algorithms work correctly
- [ ] **Message format verification**: Check that DENM messages are correctly formatted and transmitted (use Wireshark or similar)
- [ ] **Integration testing**: Verify the service integrates properly with existing DenService infrastructure and doesn't interfere with other services

**Recommended test plan:**
1. Build the project and verify no compilation errors
2. Run a simple simulation with the service enabled
3. Create a traffic jam scenario and verify congestion messages are sent
4. Monitor V2X message transmission to ensure proper DENM formatting
5. Test with different penetration rates and parameter configurations

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Artery V2X Framework"
        ItsG5BaseService["ItsG5BaseService<br/>(base class)"]:::context
        LocalDynamicMap["LocalDynamicMap<br/>(vehicle tracking)"]:::context
        VehicleDataProvider["VehicleDataProvider<br/>(ego vehicle data)"]:::context
        Timer["Timer<br/>(simulation time)"]:::context
    end
    
    subgraph "New Traffic Management"
        TrafficMgmtService["TrafficManagementService.h<br/>TrafficManagementService.cc"]:::major-edit
        TrafficMgmtNED["TrafficManagementService.ned<br/>(configuration)"]:::major-edit
    end
    
    subgraph "Configuration"
        ServicesXML["scenarios/artery/services.xml<br/>(service registration)"]:::minor-edit
    end
    
    subgraph "V2X Communication"
        DENM["DENM Messages<br/>(traffic alerts)"]:::context
    end
    
    ItsG5BaseService --> TrafficMgmtService
    LocalDynamicMap --> TrafficMgmtService
    VehicleDataProvider --> TrafficMgmtService  
    Timer --> TrafficMgmtService
    TrafficMgmtService --> DENM
    TrafficMgmtNED --> TrafficMgmtService
    ServicesXML --> TrafficMgmtService
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Architectural concern**: The service extends `ItsG5BaseService` directly, but existing traffic services like `TrafficJamUseCase` extend `UseCase` and are managed by `DenService`. This may need architectural adjustment.
- **Testing limitation**: Cannot fully test traffic detection algorithms without complete OMNeT++/SUMO simulation environment
- **Message patterns**: Uses `vanetza::asn1::allocate<>()` for DENM creation instead of `createMessageSkeleton()` pattern from existing use cases

**Session details:**
- Link to Devin run: https://app.devin.ai/sessions/df43c7454c4c47c29654df6170fe7f4a
- Requested by: @amicha24 (Angelos Michalopoulos)
