### PR TITLE
feat: VehicleClusteringService (CAM-based clustering)

### DIFF
--- a/scenarios/artery/services-vehicle-clustering.xml
+++ b/scenarios/artery/services-vehicle-clustering.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services>
+  <service type="artery.application.CaService" name="CA">
+    <listener port="2001" />
+  </service>
+  <service type="artery.application.VehicleClusteringService" name="Clustering">
+  </service>
+</services>

--- a/src/artery/CMakeLists.txt
+++ b/src/artery/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(core SHARED
     application/DenmObject.cc
     application/DenService.cc
     application/ExampleService.cc
+    application/VehicleClusteringService.cc
     application/GbcMockMessage.cc
     application/GbcMockService.cc
     application/InfrastructureMockMessage.cc

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -78,7 +78,7 @@ void VehicleClusteringService::trigger()
     emitStats(clusters);
 }
 
-void VehicleClusteringService::receiveSignal(cComponent*, simsignal_t signal, cObject*, cObject*)
+void VehicleClusteringService::receiveSignal(cComponent* /*source*/, simsignal_t signal, cObject* /*obj*/, cObject* /*details*/)
 {
     if (signal == scSignalCamReceived) {
         // no-op; subscribed to maintain awareness of neighbor updates

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 using namespace omnetpp;
 
@@ -107,8 +108,9 @@ std::vector<VehicleClusteringService::Member> VehicleClusteringService::collectM
         const auto& hf = cam.cam.camParameters.highFrequencyContainer;
         Member m;
         m.stationId = cam.header.stationID;
-        m.lat = bc.referencePosition.latitude.value();
-        m.lon = bc.referencePosition.longitude.value();
+        static constexpr double kMicroDeg = 1e6;
+        m.lat = static_cast<double>(bc.referencePosition.latitude) / kMicroDeg;
+        m.lon = static_cast<double>(bc.referencePosition.longitude) / kMicroDeg;
         m.speedKmh = vanetza::facilities::speed_value_kmh(hf.basicVehicleContainerHighFrequency.speed);
         m.lastSeen = now;
         out.push_back(m);

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -1,5 +1,6 @@
 #include "artery/application/VehicleClusteringService.h"
 
+#include <vanetza/asn1/cam.hpp>
 #include <vanetza/facilities/cam_functions.hpp>
 
 #include <algorithm>
@@ -78,11 +79,9 @@ void VehicleClusteringService::trigger()
     emitStats(clusters);
 }
 
-void VehicleClusteringService::receiveSignal(cComponent* source, simsignal_t signal, cObject* obj, cObject* details)
+void VehicleClusteringService::receiveSignal(
+    [[maybe_unused]] cComponent* source, simsignal_t signal, [[maybe_unused]] cObject* obj, [[maybe_unused]] cObject* details)
 {
-    (void)source;
-    (void)obj;
-    (void)details;
     if (signal == scSignalCamReceived) {
         // no-op; subscribed to maintain awareness of neighbor updates
     }

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -117,6 +117,7 @@ std::vector<VehicleClusteringService::Member> VehicleClusteringService::collectM
 }
 
 static constexpr double kPi = 3.14159265358979323846;
+static constexpr double kHuge = 1e100;
 static inline double deg2rad(double d)
 {
     return d * kPi / 180.0;
@@ -237,7 +238,7 @@ void VehicleClusteringService::chooseHeads(std::vector<Cluster>& clusters)
             }
             c.centroidLat = latSum / c.members.size();
             c.centroidLon = lonSum / c.members.size();
-            double best = 1e100;
+            double best = kHuge;
             uint32_t head = 0;
             for (auto& m : c.members) {
                 double d = geoDistanceMeters(m.lat, m.lon, c.centroidLat, c.centroidLon);
@@ -248,7 +249,7 @@ void VehicleClusteringService::chooseHeads(std::vector<Cluster>& clusters)
             }
             c.headStationId = head;
         } else {
-            double best = 1e100;
+            double best = kHuge;
             uint32_t head = 0;
             for (auto& m : c.members) {
                 double d = std::abs(m.speedKmh - c.medianSpeedKmh);

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <string>
+
 
 namespace artery
 {

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -36,7 +36,6 @@ void VehicleClusteringService::initialize()
     mEpsilonMeters = par("epsilonRadius");
     mMinPts = par("minPts");
     mSpeedToleranceKmh = par("speedTolerance");
-    mWindowSeconds = par("windowSeconds");
     mIncludeSelf = par("includeSelf");
     mAllowSingletons = par("allowSingletons");
     mHeadStickiness = par("headStickiness");

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -1,0 +1,274 @@
+#include "artery/application/VehicleClusteringService.h"
+#include "artery/utility/InitStages.h"
+#include "artery/traci/VehicleController.h"
+#include <vanetza/facilities/cam_functions.hpp>
+#include <algorithm>
+#include <cmath>
+
+using namespace omnetpp;
+
+namespace artery
+{
+
+static const simsignal_t scSignalCamReceived = cComponent::registerSignal("CamReceived");
+static const simsignal_t scClusterCount = cComponent::registerSignal("ClusterCount");
+static const simsignal_t scClusterHead = cComponent::registerSignal("ClusterHead");
+static const simsignal_t scClusterSize = cComponent::registerSignal("ClusterSize");
+
+Define_Module(VehicleClusteringService)
+
+VehicleClusteringService::VehicleClusteringService()
+{
+}
+
+VehicleClusteringService::~VehicleClusteringService()
+{
+    cancelAndDelete(mTick);
+}
+
+void VehicleClusteringService::initialize()
+{
+    ItsG5Service::initialize();
+
+    const std::string mode = par("mode").stdstringValue();
+    mMode = (mode == "speed") ? Mode::Speed : Mode::Spatial;
+    mInterval = par("clusteringInterval");
+    mEpsilonMeters = par("epsilonRadius");
+    mMinPts = par("minPts");
+    mSpeedToleranceKmh = par("speedTolerance");
+    mWindowSeconds = par("windowSeconds");
+    mIncludeSelf = par("includeSelf");
+    mAllowSingletons = par("allowSingletons");
+    mHeadStickiness = par("headStickiness");
+    mReassignmentCooldown = par("reassignmentCooldown");
+
+    mLdm = &getFacilities().get_const<LocalDynamicMap>();
+    mVdp = &getFacilities().get_const<VehicleDataProvider>();
+    mTimer = &getFacilities().get_const<Timer>();
+
+    subscribe(scSignalCamReceived);
+    mTick = new cMessage("VehicleClustering tick");
+    scheduleAt(simTime() + mInterval, mTick);
+}
+
+void VehicleClusteringService::finish()
+{
+    getMiddleware().unsubscribe(scSignalCamReceived, this);
+    ItsG5Service::finish();
+}
+
+void VehicleClusteringService::handleMessage(cMessage* msg)
+{
+    if (msg == mTick) {
+        trigger();
+        scheduleAt(simTime() + mInterval, mTick);
+    } else {
+        ItsG5Service::handleMessage(msg);
+    }
+}
+
+void VehicleClusteringService::trigger()
+{
+    auto members = collectMembers();
+    if (members.empty()) {
+        emit(scClusterCount, 0L);
+        return;
+    }
+
+    std::vector<Cluster> clusters = (mMode == Mode::Spatial) ? clusterSpatial(members) : clusterSpeed(members);
+    chooseHeads(clusters);
+    emitStats(clusters);
+}
+
+void VehicleClusteringService::receiveSignal(cComponent*, simsignal_t signal, cObject*, cObject*)
+{
+    if (signal == scSignalCamReceived) {
+        mDirty = true;
+    }
+}
+
+std::vector<VehicleClusteringService::Member> VehicleClusteringService::collectMembers() const
+{
+    std::vector<Member> out;
+    const SimTime now = simTime();
+
+    if (mIncludeSelf) {
+        Member self;
+        self.stationId = mVdp->station_id();
+        self.lat = mVdp->latitude().value();
+        self.lon = mVdp->longitude().value();
+        self.speedKmh = mVdp->speed().value() * 3.6;
+        self.lastSeen = now;
+        out.push_back(self);
+    }
+
+    const auto& entries = mLdm->allEntries();
+    for (const auto& kv : entries) {
+        const auto& cam = kv.second.cam();
+        const auto& bc = cam->cam.camParameters.basicContainer;
+        const auto& hf = cam->cam.camParameters.highFrequencyContainer;
+        Member m;
+        m.stationId = cam->header.stationID;
+        m.lat = bc.referencePosition.latitude.value();
+        m.lon = bc.referencePosition.longitude.value();
+        m.speedKmh = vanetza::facilities::speed_value_kmh(hf.basicVehicleContainerHighFrequency.speed);
+        m.lastSeen = now;
+        out.push_back(m);
+    }
+    return out;
+}
+
+static inline double deg2rad(double d) { return d * M_PI / 180.0; }
+
+double VehicleClusteringService::geoDistanceMeters(double lat1, double lon1, double lat2, double lon2)
+{
+    static const double R = 6371000.0;
+    const double dLat = deg2rad(lat2 - lat1);
+    const double dLon = deg2rad(lon2 - lon1);
+    const double a = std::sin(dLat/2)*std::sin(dLat/2) +
+                     std::cos(deg2rad(lat1))*std::cos(deg2rad(lat2))*
+                     std::sin(dLon/2)*std::sin(dLon/2);
+    const double c = 2 * std::atan2(std::sqrt(a), std::sqrt(1-a));
+    return R * c;
+}
+
+std::vector<VehicleClusteringService::Cluster>
+VehicleClusteringService::clusterSpatial(const std::vector<Member>& mbs)
+{
+    const double eps = mEpsilonMeters;
+    const int minPts = mMinPts;
+    const int n = static_cast<int>(mbs.size());
+    std::vector<int> labels(n, -1);
+    int clusterId = 0;
+
+    auto regionQuery = [&](int i) {
+        std::vector<int> neighbors;
+        for (int j = 0; j < n; ++j) {
+            if (i == j) continue;
+            if (geoDistanceMeters(mbs[i].lat, mbs[i].lon, mbs[j].lat, mbs[j].lon) <= eps) {
+                neighbors.push_back(j);
+            }
+        }
+        return neighbors;
+    };
+
+    for (int i = 0; i < n; ++i) {
+        if (labels[i] != -1) continue;
+        auto neighbors = regionQuery(i);
+        if (static_cast<int>(neighbors.size()) + 1 < minPts) {
+            labels[i] = mAllowSingletons ? clusterId++ : -2;
+            continue;
+        }
+        labels[i] = clusterId;
+        std::vector<int> seeds = neighbors;
+        for (size_t k = 0; k < seeds.size(); ++k) {
+            int p = seeds[k];
+            if (labels[p] == -2) labels[p] = clusterId;
+            if (labels[p] != -1) continue;
+            labels[p] = clusterId;
+            auto n2 = regionQuery(p);
+            if (static_cast<int>(n2.size()) + 1 >= minPts) {
+                seeds.insert(seeds.end(), n2.begin(), n2.end());
+            }
+        }
+        clusterId++;
+    }
+
+    std::vector<Cluster> clusters;
+    clusters.resize(clusterId);
+    for (int cid = 0; cid < clusterId; ++cid) {
+        clusters[cid].id = cid;
+    }
+    for (int i = 0; i < n; ++i) {
+        int cid = labels[i];
+        if (cid >= 0) clusters[cid].members.push_back(mbs[i]);
+    }
+    return clusters;
+}
+
+double VehicleClusteringService::median(std::vector<double> v)
+{
+    if (v.empty()) return 0.0;
+    std::sort(v.begin(), v.end());
+    size_t m = v.size() / 2;
+    if (v.size() % 2) return v[m];
+    return 0.5 * (v[m-1] + v[m]);
+}
+
+std::vector<VehicleClusteringService::Cluster>
+VehicleClusteringService::clusterSpeed(const std::vector<Member>& mbs)
+{
+    std::vector<double> speeds;
+    speeds.reserve(mbs.size());
+    for (auto& m : mbs) speeds.push_back(m.speedKmh);
+    double med = median(speeds);
+    const double tol = mSpeedToleranceKmh;
+
+    Cluster c;
+    c.id = 0;
+    for (auto& m : mbs) {
+        if (std::abs(m.speedKmh - med) <= tol) c.members.push_back(m);
+    }
+    if (!mAllowSingletons && static_cast<int>(c.members.size()) < mMinPts) {
+        return {};
+    }
+    c.medianSpeedKmh = med;
+    return { c };
+}
+
+void VehicleClusteringService::chooseHeads(std::vector<Cluster>& clusters)
+{
+    const SimTime now = simTime();
+    for (auto& c : clusters) {
+        if (c.members.empty()) continue;
+        if (mMode == Mode::Spatial) {
+            double latSum = 0.0, lonSum = 0.0;
+            for (auto& m : c.members) { latSum += m.lat; lonSum += m.lon; }
+            c.centroidLat = latSum / c.members.size();
+            c.centroidLon = lonSum / c.members.size();
+            double best = 1e100;
+            uint32_t head = 0;
+            for (auto& m : c.members) {
+                double d = geoDistanceMeters(m.lat, m.lon, c.centroidLat, c.centroidLon);
+                if (d < best || (std::abs(d - best) < 1e-6 && m.stationId < head)) {
+                    best = d; head = m.stationId;
+                }
+            }
+            c.headStationId = head;
+        } else {
+            double best = 1e100;
+            uint32_t head = 0;
+            for (auto& m : c.members) {
+                double d = std::abs(m.speedKmh - c.medianSpeedKmh);
+                if (d < best || (std::abs(d - best) < 1e-6 && m.stationId < head)) {
+                    best = d; head = m.stationId;
+                }
+            }
+            c.headStationId = head;
+        }
+
+        if (mHeadStickiness) {
+            auto it = mHeads.find(c.id);
+            if (it != mHeads.end() && it->second != 0 && now - mLastAssignmentChange < mReassignmentCooldown) {
+                c.headStationId = it->second;
+            }
+            if (mHeads[c.id] != c.headStationId) {
+                mHeads[c.id] = c.headStationId;
+                mLastAssignmentChange = now;
+            }
+        } else {
+            mHeads[c.id] = c.headStationId;
+        }
+    }
+}
+
+void VehicleClusteringService::emitStats(const std::vector<Cluster>& clusters)
+{
+    emit(scClusterCount, static_cast<long>(clusters.size()));
+    for (const auto& c : clusters) {
+        emit(scClusterSize, static_cast<long>(c.members.size()));
+        emit(scClusterHead, static_cast<long>(c.headStationId));
+    }
+}
+
+} // namespace artery

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -116,9 +116,10 @@ std::vector<VehicleClusteringService::Member> VehicleClusteringService::collectM
     return out;
 }
 
+static constexpr double kPi = 3.14159265358979323846;
 static inline double deg2rad(double d)
 {
-    return d * M_PI / 180.0;
+    return d * kPi / 180.0;
 }
 
 double VehicleClusteringService::geoDistanceMeters(double lat1, double lon1, double lat2, double lon2)

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -82,7 +82,7 @@ void VehicleClusteringService::trigger()
 void VehicleClusteringService::receiveSignal(cComponent*, simsignal_t signal, cObject*, cObject*)
 {
     if (signal == scSignalCamReceived) {
-        mDirty = true;
+        // no-op; subscribed to maintain awareness of neighbor updates
     }
 }
 
@@ -104,10 +104,10 @@ std::vector<VehicleClusteringService::Member> VehicleClusteringService::collectM
     const auto& entries = mLdm->allEntries();
     for (const auto& kv : entries) {
         const auto& cam = kv.second.cam();
-        const auto& bc = cam->cam.camParameters.basicContainer;
-        const auto& hf = cam->cam.camParameters.highFrequencyContainer;
+        const auto& bc = cam.cam.camParameters.basicContainer;
+        const auto& hf = cam.cam.camParameters.highFrequencyContainer;
         Member m;
-        m.stationId = cam->header.stationID;
+        m.stationId = cam.header.stationID;
         m.lat = bc.referencePosition.latitude.value();
         m.lon = bc.referencePosition.longitude.value();
         m.speedKmh = vanetza::facilities::speed_value_kmh(hf.basicVehicleContainerHighFrequency.speed);

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -1,6 +1,4 @@
 #include "artery/application/VehicleClusteringService.h"
-#include "artery/utility/InitStages.h"
-#include "artery/traci/VehicleController.h"
 #include <vanetza/facilities/cam_functions.hpp>
 #include <algorithm>
 #include <cmath>
@@ -44,7 +42,6 @@ void VehicleClusteringService::initialize()
 
     mLdm = &getFacilities().get_const<LocalDynamicMap>();
     mVdp = &getFacilities().get_const<VehicleDataProvider>();
-    mTimer = &getFacilities().get_const<Timer>();
 
     subscribe(scSignalCamReceived);
     mTick = new cMessage("VehicleClustering tick");
@@ -53,7 +50,7 @@ void VehicleClusteringService::initialize()
 
 void VehicleClusteringService::finish()
 {
-    getMiddleware().unsubscribe(scSignalCamReceived, this);
+    unsubscribe(scSignalCamReceived);
     ItsG5Service::finish();
 }
 

--- a/src/artery/application/VehicleClusteringService.cc
+++ b/src/artery/application/VehicleClusteringService.cc
@@ -111,7 +111,7 @@ std::vector<VehicleClusteringService::Member> VehicleClusteringService::collectM
         static constexpr double kMicroDeg = 1e6;
         m.lat = static_cast<double>(bc.referencePosition.latitude) / kMicroDeg;
         m.lon = static_cast<double>(bc.referencePosition.longitude) / kMicroDeg;
-        m.speedKmh = vanetza::facilities::speed_value_kmh(hf.basicVehicleContainerHighFrequency.speed);
+        m.speedKmh = vanetza::facilities::speed_value_kmh(hf.choice.basicVehicleContainerHighFrequency.speed);
         m.lastSeen = now;
         out.push_back(m);
     }
@@ -208,14 +208,14 @@ std::vector<VehicleClusteringService::Cluster> VehicleClusteringService::cluster
 {
     std::vector<double> speeds;
     speeds.reserve(mbs.size());
-    for (auto& m : mbs)
+    for (const auto& m : mbs)
         speeds.push_back(m.speedKmh);
     double med = median(speeds);
     const double tol = mSpeedToleranceKmh;
 
     Cluster c;
     c.id = 0;
-    for (auto& m : mbs) {
+    for (const auto& m : mbs) {
         if (std::abs(m.speedKmh - med) <= tol)
             c.members.push_back(m);
     }
@@ -234,7 +234,7 @@ void VehicleClusteringService::chooseHeads(std::vector<Cluster>& clusters)
             continue;
         if (mMode == Mode::Spatial) {
             double latSum = 0.0, lonSum = 0.0;
-            for (auto& m : c.members) {
+            for (const auto& m : c.members) {
                 latSum += m.lat;
                 lonSum += m.lon;
             }
@@ -242,7 +242,7 @@ void VehicleClusteringService::chooseHeads(std::vector<Cluster>& clusters)
             c.centroidLon = lonSum / c.members.size();
             double best = kHuge;
             uint32_t head = 0;
-            for (auto& m : c.members) {
+            for (const auto& m : c.members) {
                 double d = geoDistanceMeters(m.lat, m.lon, c.centroidLat, c.centroidLon);
                 if (d < best || (std::abs(d - best) < 1e-6 && m.stationId < head)) {
                     best = d;
@@ -253,7 +253,7 @@ void VehicleClusteringService::chooseHeads(std::vector<Cluster>& clusters)
         } else {
             double best = kHuge;
             uint32_t head = 0;
-            for (auto& m : c.members) {
+            for (const auto& m : c.members) {
                 double d = std::abs(m.speedKmh - c.medianSpeedKmh);
                 if (d < best || (std::abs(d - best) < 1e-6 && m.stationId < head)) {
                     best = d;

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -5,10 +5,10 @@
 #include "artery/application/LocalDynamicMap.h"
 #include "artery/application/VehicleDataProvider.h"
 
-#include <omnetpp/simtime.h>
 #include <omnetpp/cmessage.h>
-#include <cstdint>
+#include <omnetpp/simtime.h>
 
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -60,7 +60,6 @@ private:
     const VehicleDataProvider* mVdp = nullptr;
 
     omnetpp::cMessage* mTick = nullptr;
-    bool mDirty = false;
     std::unordered_map<int, uint32_t> mHeads;
     omnetpp::SimTime mLastAssignmentChange = omnetpp::SimTime::ZERO;
 

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -55,7 +55,7 @@ private:
     bool mIncludeSelf = true;
     bool mAllowSingletons = false;
     bool mHeadStickiness = true;
-    omnetpp::SimTime mReassignmentCooldown = 2.0;
+    omnetpp::SimTime mReassignmentCooldown = omnetpp::SimTime::ZERO;
 
     const LocalDynamicMap* mLdm = nullptr;
     const VehicleDataProvider* mVdp = nullptr;

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -1,0 +1,78 @@
+#ifndef ARTERY_VEHICLECLUSTERINGSERVICE_H_
+#define ARTERY_VEHICLECLUSTERINGSERVICE_H_
+
+#include "artery/application/ItsG5Service.h"
+#include "artery/application/LocalDynamicMap.h"
+#include "artery/application/VehicleDataProvider.h"
+#include "artery/application/Timer.h"
+#include <omnetpp/cmessage.h>
+#include <unordered_map>
+#include <vector>
+
+namespace artery
+{
+
+class VehicleClusteringService : public ItsG5Service
+{
+    public:
+        VehicleClusteringService();
+        ~VehicleClusteringService() override;
+
+    protected:
+        void initialize() override;
+        void finish() override;
+        void handleMessage(omnetpp::cMessage*) override;
+        void trigger() override;
+        void receiveSignal(omnetpp::cComponent*, omnetpp::simsignal_t, omnetpp::cObject*, omnetpp::cObject*) override;
+
+    private:
+        enum class Mode { Spatial, Speed };
+
+        struct Member {
+            uint32_t stationId;
+            double lat;
+            double lon;
+            double speedKmh;
+            omnetpp::SimTime lastSeen;
+        };
+        struct Cluster {
+            int id;
+            std::vector<Member> members;
+            uint32_t headStationId = 0;
+            double centroidLat = 0.0;
+            double centroidLon = 0.0;
+            double medianSpeedKmh = 0.0;
+        };
+
+        Mode mMode = Mode::Spatial;
+        omnetpp::SimTime mInterval;
+        double mEpsilonMeters = 50.0;
+        int mMinPts = 3;
+        double mSpeedToleranceKmh = 5.0;
+        omnetpp::SimTime mWindowSeconds = 1.0;
+        bool mIncludeSelf = true;
+        bool mAllowSingletons = false;
+        bool mHeadStickiness = true;
+        omnetpp::SimTime mReassignmentCooldown = 2.0;
+
+        const LocalDynamicMap* mLdm = nullptr;
+        const VehicleDataProvider* mVdp = nullptr;
+        const Timer* mTimer = nullptr;
+
+        omnetpp::cMessage* mTick = nullptr;
+        bool mDirty = false;
+        std::unordered_map<int, uint32_t> mHeads;
+        omnetpp::SimTime mLastAssignmentChange = omnetpp::SimTime::ZERO;
+
+        std::vector<Member> collectMembers() const;
+        std::vector<Cluster> clusterSpatial(const std::vector<Member>&);
+        std::vector<Cluster> clusterSpeed(const std::vector<Member>&);
+        static double geoDistanceMeters(double lat1, double lon1, double lat2, double lon2);
+        static double median(std::vector<double> v);
+        void chooseHeads(std::vector<Cluster>&);
+        void emitStats(const std::vector<Cluster>&);
+};
+
+} // namespace artery
+
+#endif /* ARTERY_VEHICLECLUSTERINGSERVICE_H_ */

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -5,6 +5,7 @@
 #include "artery/application/LocalDynamicMap.h"
 #include "artery/application/VehicleDataProvider.h"
 
+#include <omnetpp/simtime.h>
 #include <omnetpp/cmessage.h>
 
 #include <unordered_map>

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -7,6 +7,7 @@
 
 #include <omnetpp/simtime.h>
 #include <omnetpp/cmessage.h>
+#include <cstdint>
 
 #include <unordered_map>
 #include <vector>

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -4,7 +4,9 @@
 #include "artery/application/ItsG5Service.h"
 #include "artery/application/LocalDynamicMap.h"
 #include "artery/application/VehicleDataProvider.h"
+
 #include <omnetpp/cmessage.h>
+
 #include <unordered_map>
 #include <vector>
 
@@ -13,64 +15,64 @@ namespace artery
 
 class VehicleClusteringService : public ItsG5Service
 {
-    public:
-        VehicleClusteringService();
-        ~VehicleClusteringService() override;
+public:
+    VehicleClusteringService();
+    ~VehicleClusteringService() override;
 
-    protected:
-        void initialize() override;
-        void finish() override;
-        void handleMessage(omnetpp::cMessage*) override;
-        void trigger() override;
-        void receiveSignal(omnetpp::cComponent*, omnetpp::simsignal_t, omnetpp::cObject*, omnetpp::cObject*) override;
+protected:
+    void initialize() override;
+    void finish() override;
+    void handleMessage(omnetpp::cMessage*) override;
+    void trigger() override;
+    void receiveSignal(omnetpp::cComponent*, omnetpp::simsignal_t, omnetpp::cObject*, omnetpp::cObject*) override;
 
-    private:
-        enum class Mode { Spatial, Speed };
+private:
+    enum class Mode { Spatial, Speed };
 
-        struct Member {
-            uint32_t stationId;
-            double lat;
-            double lon;
-            double speedKmh;
-            omnetpp::SimTime lastSeen;
-        };
-        struct Cluster {
-            int id;
-            std::vector<Member> members;
-            uint32_t headStationId = 0;
-            double centroidLat = 0.0;
-            double centroidLon = 0.0;
-            double medianSpeedKmh = 0.0;
-        };
+    struct Member {
+        uint32_t stationId;
+        double lat;
+        double lon;
+        double speedKmh;
+        omnetpp::SimTime lastSeen;
+    };
+    struct Cluster {
+        int id;
+        std::vector<Member> members;
+        uint32_t headStationId = 0;
+        double centroidLat = 0.0;
+        double centroidLon = 0.0;
+        double medianSpeedKmh = 0.0;
+    };
 
-        Mode mMode = Mode::Spatial;
-        omnetpp::SimTime mInterval;
-        double mEpsilonMeters = 50.0;
-        int mMinPts = 3;
-        double mSpeedToleranceKmh = 5.0;
-        omnetpp::SimTime mWindowSeconds = 1.0;
-        bool mIncludeSelf = true;
-        bool mAllowSingletons = false;
-        bool mHeadStickiness = true;
-        omnetpp::SimTime mReassignmentCooldown = 2.0;
+    Mode mMode = Mode::Spatial;
+    omnetpp::SimTime mInterval;
+    double mEpsilonMeters = 50.0;
+    int mMinPts = 3;
+    double mSpeedToleranceKmh = 5.0;
+    omnetpp::SimTime mWindowSeconds = 1.0;
+    bool mIncludeSelf = true;
+    bool mAllowSingletons = false;
+    bool mHeadStickiness = true;
+    omnetpp::SimTime mReassignmentCooldown = 2.0;
 
-        const LocalDynamicMap* mLdm = nullptr;
-        const VehicleDataProvider* mVdp = nullptr;
+    const LocalDynamicMap* mLdm = nullptr;
+    const VehicleDataProvider* mVdp = nullptr;
 
-        omnetpp::cMessage* mTick = nullptr;
-        bool mDirty = false;
-        std::unordered_map<int, uint32_t> mHeads;
-        omnetpp::SimTime mLastAssignmentChange = omnetpp::SimTime::ZERO;
+    omnetpp::cMessage* mTick = nullptr;
+    bool mDirty = false;
+    std::unordered_map<int, uint32_t> mHeads;
+    omnetpp::SimTime mLastAssignmentChange = omnetpp::SimTime::ZERO;
 
-        std::vector<Member> collectMembers() const;
-        std::vector<Cluster> clusterSpatial(const std::vector<Member>&);
-        std::vector<Cluster> clusterSpeed(const std::vector<Member>&);
-        static double geoDistanceMeters(double lat1, double lon1, double lat2, double lon2);
-        static double median(std::vector<double> v);
-        void chooseHeads(std::vector<Cluster>&);
-        void emitStats(const std::vector<Cluster>&);
+    std::vector<Member> collectMembers() const;
+    std::vector<Cluster> clusterSpatial(const std::vector<Member>&);
+    std::vector<Cluster> clusterSpeed(const std::vector<Member>&);
+    static double geoDistanceMeters(double lat1, double lon1, double lat2, double lon2);
+    static double median(std::vector<double> v);
+    void chooseHeads(std::vector<Cluster>&);
+    void emitStats(const std::vector<Cluster>&);
 };
 
-} // namespace artery
+}  // namespace artery
 
 #endif /* ARTERY_VEHICLECLUSTERINGSERVICE_H_ */

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -50,7 +50,6 @@ private:
     double mEpsilonMeters = 50.0;
     int mMinPts = 3;
     double mSpeedToleranceKmh = 5.0;
-    omnetpp::SimTime mWindowSeconds = 1.0;
     bool mIncludeSelf = true;
     bool mAllowSingletons = false;
     bool mHeadStickiness = true;

--- a/src/artery/application/VehicleClusteringService.h
+++ b/src/artery/application/VehicleClusteringService.h
@@ -4,7 +4,6 @@
 #include "artery/application/ItsG5Service.h"
 #include "artery/application/LocalDynamicMap.h"
 #include "artery/application/VehicleDataProvider.h"
-#include "artery/application/Timer.h"
 #include <omnetpp/cmessage.h>
 #include <unordered_map>
 #include <vector>
@@ -57,7 +56,6 @@ class VehicleClusteringService : public ItsG5Service
 
         const LocalDynamicMap* mLdm = nullptr;
         const VehicleDataProvider* mVdp = nullptr;
-        const Timer* mTimer = nullptr;
 
         omnetpp::cMessage* mTick = nullptr;
         bool mDirty = false;

--- a/src/artery/application/VehicleClusteringService.ned
+++ b/src/artery/application/VehicleClusteringService.ned
@@ -1,0 +1,30 @@
+package artery.application;
+
+import artery.application.ItsG5Service;
+
+simple VehicleClusteringService like ItsG5Service
+{
+    parameters:
+        @signal[ClusterCount](type=long);
+        @signal[ClusterHead](type=long);
+        @signal[ClusterSize](type=long);
+
+        @statistic[clusterCount](source=ClusterCount; record=vector);
+        @statistic[clusterSize](source=ClusterSize; record=histogram,vector);
+        @statistic[clusterHead](source=ClusterHead; record=vector);
+
+        string mode = default("spatial");
+        double clusteringInterval @unit(s) = default(0.5s);
+
+        double epsilonRadius @unit(m) = default(50m);
+        int minPts = default(3);
+
+        double speedTolerance @unit(km/h) = default(5);
+        double windowSeconds @unit(s) = default(1s);
+
+        bool includeSelf = default(true);
+        bool allowSingletons = default(false);
+
+        bool headStickiness = default(true);
+        double reassignmentCooldown @unit(s) = default(2s);
+}


### PR DESCRIPTION
# feat: VehicleClusteringService (CAM-based clustering)

## Summary

This PR adds a new `VehicleClusteringService` that implements vehicle clustering using CAM (Cooperative Awareness Message) sensor data. The service supports two clustering modes:

1. **Spatial clustering**: DBSCAN-like algorithm that groups vehicles within a configurable radius (default 50m)
2. **Speed clustering**: Groups vehicles with similar speeds around the median (default ±5 km/h tolerance)

The service subscribes to `CamReceived` signals, accesses neighbor data via `LocalDynamicMap`, and selects cluster heads based on proximity to cluster centroid (spatial) or median speed (speed mode). It emits OMNeT++ signals for statistics collection without broadcasting cluster information over the network.

**Key files added:**
- `VehicleClusteringService.{h,cc,ned}` - Core service implementation
- `services-vehicle-clustering.xml` - Scenario configuration example
- Updated `CMakeLists.txt` to include new service in build

## Review & Testing Checklist for Human

- [ ] **Verify compilation**: Ensure the service compiles without errors and links properly with core target
- [ ] **Test basic functionality**: Run a simple scenario with the new service and verify it initializes without crashes
- [ ] **Validate CAM data extraction**: Check that position/speed data is correctly extracted from CAM messages using vanetza facilities
- [ ] **Review clustering algorithms**: Test spatial clustering with known vehicle positions to verify DBSCAN-like behavior and distance calculations
- [ ] **Verify signal emission**: Confirm that ClusterCount, ClusterSize, and ClusterHead signals are properly emitted and can be recorded as statistics

**Recommended test plan**: Create a scenario with 5-10 vehicles in known positions, enable the clustering service, and verify that:
1. Vehicles within 50m are clustered together
2. Cluster heads are correctly identified  
3. Statistics are recorded properly
4. No runtime errors occur

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CamService["CaService.cc<br/>CAM message sender"]:::context
    CamReceived["CamReceived signal"]:::context
    VCS_h["VehicleClusteringService.h<br/>Service class definition"]:::major-edit
    VCS_cc["VehicleClusteringService.cc<br/>Clustering algorithms<br/>& CAM data processing"]:::major-edit
    VCS_ned["VehicleClusteringService.ned<br/>OMNeT++ module<br/>parameters & signals"]:::major-edit
    LDM["LocalDynamicMap.h/.cc<br/>CAM storage & access"]:::context
    VDP["VehicleDataProvider<br/>Self vehicle data"]:::context
    CMake["CMakeLists.txt<br/>Build configuration"]:::minor-edit
    Scenario["services-vehicle-clustering.xml<br/>Scenario wiring"]:::major-edit
    
    CamService --> CamReceived
    CamReceived --> VCS_cc
    VCS_cc --> LDM
    VCS_cc --> VDP
    VCS_h --> VCS_cc
    VCS_ned --> VCS_cc
    CMake --> VCS_cc
    Scenario --> VCS_ned
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The service uses Haversine formula for geographic distance calculations, which is appropriate for the expected clustering ranges
- Cluster head selection includes tie-breaking logic using station IDs for deterministic results
- Hysteresis parameters (headStickiness, reassignmentCooldown) help prevent cluster head oscillation
- No network transmission is performed - this is purely a local analysis service

**Session details**: Requested by Angelos Michalopoulos (@amicha24)  
**Devin run**: https://app.devin.ai/sessions/55aa0a72920e4e9ea9fdf4b72eccb44e